### PR TITLE
Changed deprecated Config to RbConfig in util.rb

### DIFF
--- a/lib/graphviz/utils.rb
+++ b/lib/graphviz/utils.rb
@@ -23,7 +23,7 @@ module GVUtils
       file = (path.nil?)?bin:File.join(path,bin)
       if File.executable?(file) and not File.directory?(file) then
         return file
-      elsif Config::CONFIG['host_os'] =~ /mswin|mingw/ # WAS: elsif RUBY_PLATFORM =~ /mswin|mingw/
+      elsif RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ # WAS: elsif RUBY_PLATFORM =~ /mswin|mingw/
         found_ext = (ENV['PATHEXT'] || '.exe;.bat;.com').split(";").find {|ext| File.executable?(file + ext) }
         return file + found_ext if found_ext
       end


### PR DESCRIPTION
as per deprecation warning in ruby 1.9.3:
  .../ruby-1.9.3-p0/gems/ruby-graphviz-1.0.0/lib/graphviz/utils.rb:26: Use RbConfig instead of obsolete and deprecated Config.
