### PR TITLE
Removed definition of Array#all? from core_ext.rb

### DIFF
--- a/lib/graphviz/core_ext.rb
+++ b/lib/graphviz/core_ext.rb
@@ -23,15 +23,6 @@ class Object
    end
 end
 
-class Array
-   def all?(&b)
-      r = self.delete_if { |x|
-         yield x
-      }
-      r.size == 0
-   end
-end
-
 # From : http://www.geekmade.co.uk/2008/09/ruby-tip-normalizing-hash-keys-as-symbols/
 class Hash
    def symbolize_keys


### PR DESCRIPTION
I don't know why core_ext defines Array#all? since Enumerable#all? does the same thing (in MRI 1.8.7 and 1.9.3)

Except that this extension doesn't support the behaviour that "If the block is not given, Ruby adds an implicit block of {|obj| obj} (that is all? will return true only if none of the collection members are false or nil.)" http://www.ruby-doc.org/core-1.9.3/Enumerable.html#method-i-all-3F 

So with this definition, including ruby-graphviz breaks any existing code that calls an_array.all? without a block.  (Not hypothetical -- I updated my project to the latest version of ruby-graphviz and my project broke!)

And without this local extension, the tests seem to pass anyway (again, in MRI 1.8.7 and 1.9.3).
