### PR TITLE
Added lib/ruby-graphviz to match the gem name.

### DIFF
--- a/lib/ruby-graphviz.rb
+++ b/lib/ruby-graphviz.rb
@@ -1,0 +1,1 @@
+require 'graphviz'


### PR DESCRIPTION
This is helpful for developers who bundle ruby-graphviz, but do not use the `:require` option in their Gemfile.
