### PR TITLE
do not fail if @filename has spaces.

### DIFF
--- a/lib/graphviz.rb
+++ b/lib/graphviz.rb
@@ -601,7 +601,7 @@ class GraphViz
           if @filename.nil? or @filename == String
             xOutputWithoutFile = "-T#{@format} "
           else
-            xOutputWithFile = "-T#{@format} -o#{@filename} "
+            xOutputWithFile = "-T#{@format} -o'#{@filename}' "
           end
         end
         @output.each_except( :key => ["none"] ) do |format, file|


### PR DESCRIPTION
No test in the PR but it should fix AFAICT. I used the backtrace to fix it. I got this error:

<pre>
/Users/shair/.rvm/gems/ruby-1.9.3-p392/gems/ruby-graphviz-1.0.9/lib/graphviz/utils.rb:77:in `output_from_command': Error from "/usr/local/bin/dot" -q1   -Tpng -ocourse_dep_with a space.png   /var/folders/x0/kp053jk11bg93w_rr2j8m9zh0000gq/T/graphviz.rb20131114-24816-b2aetd: (RuntimeError)
Error: dot: can't open a space.png
    from /Users/shair/.rvm/gems/ruby-1.9.3-p392/gems/ruby-graphviz-1.0.9/lib/graphviz.rb:589:in `output'
    from graph_lessons.rb:30:in `<main>'
</pre>


When trying to save like this:

<pre>g.output(:png => "course_dep_#{name_with_spaces}.png")</pre>


Either way, thanks for this great gem!
