### PR TITLE
only escape Edge#node_one and Edge#node_two when output

### DIFF
--- a/lib/graphviz/edge.rb
+++ b/lib/graphviz/edge.rb
@@ -18,151 +18,151 @@ require 'graphviz/attrs'
 require 'graphviz/constants'
 
 class GraphViz
-   class Edge
-      include GraphViz::Constants
+  class Edge
+    include GraphViz::Constants
 
-      # Create a new edge
-      #
-      # In:
-      # * vNodeOne : First node (can be a GraphViz::Node or a node ID)
-      # * vNodeTwo : Second node (can be a GraphViz::Node or a node ID)
-      # * parent_graph : Graph
-      def initialize( vNodeOne, vNodeTwo, parent_graph )
-         @node_one_id, @node_one_port = getNodeNameAndPort( vNodeOne )
-         @node_two_id, @node_two_port = getNodeNameAndPort( vNodeTwo )
+    # Create a new edge
+    #
+    # In:
+    # * vNodeOne : First node (can be a GraphViz::Node or a node ID)
+    # * vNodeTwo : Second node (can be a GraphViz::Node or a node ID)
+    # * parent_graph : Graph
+    def initialize( vNodeOne, vNodeTwo, parent_graph )
+      @node_one_id, @node_one_port = getNodeNameAndPort( vNodeOne )
+      @node_two_id, @node_two_port = getNodeNameAndPort( vNodeTwo )
 
-         @parent_graph = parent_graph
-         @edge_attributes = GraphViz::Attrs::new( nil, "edge", EDGESATTRS )
-         @index = nil
+      @parent_graph = parent_graph
+      @edge_attributes = GraphViz::Attrs::new( nil, "edge", EDGESATTRS )
+      @index = nil
 
-         unless @parent_graph.directed?
-            (@parent_graph.find_node(@node_one_id) || @parent_graph.add_nodes(@node_one_id)).incidents << (@parent_graph.find_node(@node_two_id) || @parent_graph.add_nodes(@node_two_id))
-            (@parent_graph.find_node(@node_two_id) || @parent_graph.add_nodes(@node_two_id)).neighbors << (@parent_graph.find_node(@node_one_id) || @parent_graph.add_nodes(@node_one_id))
-         end
-         (@parent_graph.find_node(@node_one_id) || @parent_graph.add_nodes(@node_one_id)).neighbors << (@parent_graph.find_node(@node_two_id) || @parent_graph.add_nodes(@node_two_id))
-         (@parent_graph.find_node(@node_two_id) || @parent_graph.add_nodes(@node_two_id)).incidents << (@parent_graph.find_node(@node_one_id) || @parent_graph.add_nodes(@node_one_id))
+      unless @parent_graph.directed?
+        (@parent_graph.find_node(@node_one_id) || @parent_graph.add_nodes(@node_one_id)).incidents << (@parent_graph.find_node(@node_two_id) || @parent_graph.add_nodes(@node_two_id))
+        (@parent_graph.find_node(@node_two_id) || @parent_graph.add_nodes(@node_two_id)).neighbors << (@parent_graph.find_node(@node_one_id) || @parent_graph.add_nodes(@node_one_id))
       end
+      (@parent_graph.find_node(@node_one_id) || @parent_graph.add_nodes(@node_one_id)).neighbors << (@parent_graph.find_node(@node_two_id) || @parent_graph.add_nodes(@node_two_id))
+      (@parent_graph.find_node(@node_two_id) || @parent_graph.add_nodes(@node_two_id)).incidents << (@parent_graph.find_node(@node_one_id) || @parent_graph.add_nodes(@node_one_id))
+    end
 
-      # Return the node one as string (so with port if any)
-      def node_one( with_port = true )
-         if not(@node_one_port and with_port)
-            GraphViz.escape(@node_one_id)
-         else
-            GraphViz.escape(@node_one_id, :force => true) + ":#{@node_one_port}"
-         end
+    # Return the node one as string (so with port if any)
+    def node_one( with_port = true )
+      if not(@node_one_port and with_port)
+        @node_one_id
+      else
+        "#{@node_one_id}:#{@node_one_port}"
       end
-      alias :tail_node :node_one
+    end
+    alias :tail_node :node_one
 
-      # Return the node two as string (so with port if any)
-      def node_two( with_port = true )
-         if not(@node_two_port and with_port)
-            GraphViz.escape(@node_two_id)
-         else
-            GraphViz.escape(@node_two_id, :force => true) + ":#{@node_two_port}"
-         end
+    # Return the node two as string (so with port if any)
+    def node_two( with_port = true )
+      if not(@node_two_port and with_port)
+        @node_two_id
+      else
+        "#{@node_two_id}:#{@node_two_port}"
       end
-      alias :head_node :node_two
+    end
+    alias :head_node :node_two
 
-      # Return the index of the edge
-      def index
-         @index
+    # Return the index of the edge
+    def index
+      @index
+    end
+    def index=(i) #:nodoc:
+      @index = i if @index == nil
+    end
+
+    # Set value +attribute_value+ to the edge attribute +attribute_name+
+    def []=( attribute_name, attribute_value )
+      attribute_value = attribute_value.to_s if attribute_value.class == Symbol
+      @edge_attributes[attribute_name.to_s] = attribute_value
+    end
+
+    # Set values for edge attributes or
+    # get the value of the given edge attribute +attribute_name+
+    def []( attribute_name )
+      # Modification by axgle (http://github.com/axgle)
+      if Hash === attribute_name
+        attribute_name.each do |key, value|
+          self[key] = value
+        end
+      else
+        if @edge_attributes[attribute_name.to_s]
+          @edge_attributes[attribute_name.to_s].clone
+        else
+          nil
+        end
       end
-      def index=(i) #:nodoc:
-         @index = i if @index == nil
+    end
+
+    #
+    # Calls block once for each attribute of the edge, passing the name and value to the
+    # block as a two-element array.
+    #
+    # If global is set to false, the block does not receive the attributes set globally
+    #
+    def each_attribute(global = true, &b)
+      attrs = @edge_attributes.to_h
+      if global
+        attrs = pg.edge.to_h.merge attrs
       end
-
-      # Set value +attribute_value+ to the edge attribute +attribute_name+
-      def []=( attribute_name, attribute_value )
-         attribute_value = attribute_value.to_s if attribute_value.class == Symbol
-         @edge_attributes[attribute_name.to_s] = attribute_value
+      attrs.each do |k,v|
+        yield(k,v)
       end
+    end
+    def each_attribut(global = true, &b)
+      warn "`GraphViz::Edge#each_attribut` is deprecated, please use `GraphViz::Edge#each_attribute`"
+      each_attribute(global, &b)
+    end
 
-      # Set values for edge attributes or
-      # get the value of the given edge attribute +attribute_name+
-      def []( attribute_name )
-         # Modification by axgle (http://github.com/axgle)
-         if Hash === attribute_name
-            attribute_name.each do |key, value|
-               self[key] = value
-            end
-         else
-            if @edge_attributes[attribute_name.to_s]
-               @edge_attributes[attribute_name.to_s].clone
-            else
-               nil
-            end
-         end
-      end
+    def <<( node ) #:nodoc:
+      n = @parent_graph.get_node(@node_two_id)
 
-      #
-      # Calls block once for each attribute of the edge, passing the name and value to the
-      # block as a two-element array.
-      #
-      # If global is set to false, the block does not receive the attributes set globally
-      #
-      def each_attribute(global = true, &b)
-         attrs = @edge_attributes.to_h
-         if global
-            attrs = pg.edge.to_h.merge attrs
-         end
-         attrs.each do |k,v|
-            yield(k,v)
-         end
-      end
-      def each_attribut(global = true, &b)
-         warn "`GraphViz::Edge#each_attribut` is deprecated, please use `GraphViz::Edge#each_attribute`"
-         each_attribute(global, &b)
-      end
+      GraphViz::commonGraph( node, n ).add_edges( n, node )
+    end
+    alias :> :<< #:nodoc:
+    alias :- :<< #:nodoc:
+    alias :>> :<< #:nodoc:
 
-      def <<( node ) #:nodoc:
-         n = @parent_graph.get_node(@node_two_id)
+    #
+    # Return the root graph
+    #
+    def root_graph
+      return( (self.pg.nil?) ? nil : self.pg.root_graph )
+    end
 
-         GraphViz::commonGraph( node, n ).add_edges( n, node )
-      end
-      alias :> :<< #:nodoc:
-      alias :- :<< #:nodoc:
-      alias :>> :<< #:nodoc:
+    def pg #:nodoc:
+      @parent_graph
+    end
 
-      #
-      # Return the root graph
-      #
-      def root_graph
-         return( (self.pg.nil?) ? nil : self.pg.root_graph )
-      end
+    # Set edge attributes
+    #
+    # Example :
+    #   e = graph.add_edges( ... )
+    #   ...
+    #   e.set { |_e|
+    #     _e.color = "blue"
+    #     _e.fontcolor = "red"
+    #   }
+    def set( &b )
+      yield( self )
+    end
 
-      def pg #:nodoc:
-         @parent_graph
-      end
+    # Add edge options
+    # use edge.<option>=<value> or edge.<option>( <value> )
+    def method_missing( idName, *args, &block ) #:nodoc:
+      return if idName == :to_ary # ruby 1.9.2 fix
+      xName = idName.id2name
 
-      # Set edge attributes
-      #
-      # Example :
-      #   e = graph.add_edges( ... )
-      #   ...
-      #   e.set { |_e|
-      #     _e.color = "blue"
-      #     _e.fontcolor = "red"
-      #   }
-      def set( &b )
-         yield( self )
-      end
+      self[xName.gsub( /=$/, "" )]=args[0]
+    end
 
-      # Add edge options
-      # use edge.<option>=<value> or edge.<option>( <value> )
-      def method_missing( idName, *args, &block ) #:nodoc:
-         return if idName == :to_ary # ruby 1.9.2 fix
-         xName = idName.id2name
-
-         self[xName.gsub( /=$/, "" )]=args[0]
-      end
-
-      def output( oGraphType ) #:nodoc:
-         xLink = " -> "
+    def output( oGraphType ) #:nodoc:
+      xLink = " -> "
          if oGraphType == "graph"
             xLink = " -- "
          end
 
-         xOut = self.node_one + xLink + self.node_two
+         xOut = GraphViz.escape(self.node_one) + xLink + GraphViz.escape(self.node_two)
          xAttr = ""
          xSeparator = ""
          @edge_attributes.data.each do |k, v|

--- a/test/test_graph.rb
+++ b/test/test_graph.rb
@@ -104,6 +104,19 @@ class GraphVizTest < Test::Unit::TestCase
      assert_nil   c1.search_node("a0")
   end
 
+  def test_getting_escaped_node_from_edge
+    @g = GraphViz.graph "G" do |g|
+      g.add_nodes 'a@com'
+      g.add_nodes 'b@com'
+      g.add_edges 'a@com', 'b@com'
+    end
+
+    @g.each_edge do |e|
+      assert_not_nil @g.get_node e.node_one
+      assert_not_nil @g.get_node e.node_two
+    end
+  end
+
   def test_to_s
     assert_nothing_raised 'to_s with edge with numeric label failed.' do
       a = @graph.add_nodes('a')

--- a/test/test_theory.rb
+++ b/test/test_theory.rb
@@ -95,4 +95,18 @@ class GraphVizTheoryTest < Test::Unit::TestCase
       assert_equal [1, 6], r[:path]
       assert_equal 6.0, r[:distance]
    end
+
+   def test_escaped_node_ids__adjancy_matrix
+      @g = GraphViz.graph "G" do |g|
+         g.add_nodes 'a@com'
+         g.add_nodes 'b@com'
+         g.add_edges 'a@com', 'b@com'
+      end
+
+      @t = GraphViz::Theory.new( @g )
+
+      assert_nothing_raised NoMethodError do
+         @t.adjancy_matrix
+      end
+   end
 end


### PR DESCRIPTION
Theory#adjancy_matrix, Theory#incidence_matrix, and
Theory#distance_matrix all depend on Edge#node_one and Edge#node_two to
access other nodes in the graph. Because GraphViz#get_node expects an
unescaped node id, but node_one and node_two were escaping, this caused
nil to be returned from GraphViz#get_node calls.

The only place that required escaping for Edge#node_one ad Edge#node_two
was in Edge#output.

So escaping was removed from Edge#node_one and Edge#node_two, but added
to their usage in Edge#output.

This fixes #83
