### PR TITLE
Add license to gemspec

### DIFF
--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -7,18 +7,19 @@ Gem::Specification.new do |s|
   s.name = "ruby-graphviz"
   s.version = GraphViz::Constants::RGV_VERSION
   s.platform = Gem::Platform::RUBY
-  
+
   s.authors = ["Gregoire Lejeune"]
   s.summary = %q{Interface to the GraphViz graphing tool}
   s.email = %q{gregoire.lejeune@free.fr}
   s.homepage = %q{http://github.com/glejeune/Ruby-Graphviz}
   s.description = %q{Ruby/Graphviz provides an interface to layout and generate images of directed graphs in a variety of formats (PostScript, PNG, etc.) using GraphViz.}
+  s.licenses = ["MIT", "GPL-2"]
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  
+
   s.rubyforge_project = 'ruby-asp'
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc", "COPYING.rdoc", "AUTHORS.rdoc", "CHANGELOG.rdoc"]
@@ -34,7 +35,7 @@ For more information about Ruby-Graphviz :
 Last (important) changes :
 Ruby-Graphviz no longer supports Ruby < 1.9.3
   }
-  
+
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
