### PR TITLE
Make it obvious which gem this is

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -7,6 +7,7 @@ Copyright (C) 2004-2014 Gregoire Lejeune
 
 * Doc : http://rdoc.info/projects/glejeune/Ruby-Graphviz
 * Sources : http://github.com/glejeune/Ruby-Graphviz
+* On Rubygems: https://rubygems.org/gems/ruby-graphviz
 * <b>NEW</b> - Mailing List : http://groups.google.com/group/ruby-graphviz
 
 == DESCRIPTION


### PR DESCRIPTION
The examples show to "require 'graphviz'". But "gem install graphviz"
installs the wrong gem.

The "Installation" section shows the correct name, but is way below the
examples.

This confused me for several minutes, and is probably what [this user](https://groups.google.com/forum/#!topic/ruby-graphviz/T8Hx8pjxF8w) was confused about, also.