### PR TITLE
Managed to get rubinius-3.69 to build with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 rvm:
   - 2.0.0
   - 2.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 # Need sudo to install rubinius-3.69
 sudo: required
 
-# Ruby 2.1.0 is not available as a travis-ci precompiled binary for trusty
-# See http://rubies.travis-ci.org/
-before-install: rvm use 2.1.0 --install --binary --fuzzy --create
-
 # The binary for rubinius-3.69 is not available for
 # ubuntu/12.04 (Precise Pangolin) but is for ubuntu/14.04 (Trusty Tahr)
-# See https://rubinius-binaries-rubinius-com.s3-us-west-2.amazonaws.com/
+#
+# See:
+#   - https://rubinius-binaries-rubinius-com.s3-us-west-2.amazonaws.com/
+#   - "Rubinius no longer supports Precise. Please use Trusty."
+#     https://docs.travis-ci.com/user/languages/ruby/#Supported-Ruby-Versions-and-RVM
 #
 # Note: travis-ci uses precise by default
 dist: trusty
 
 rvm:
   - 2.0.0
-  - 2.1.0
+  - 2.1.10
   - 2.4.0
   - jruby
   - rubinius-3.69

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Need sudo to install rubinius-3.69
 sudo: required
 
+before-install: rvm use 2.1.0 --install --binary --fuzzy --create
+
 # The binary for rubinius-3.69 is not available for
 # ubuntu/12.04 (Precise Pangolin) but is for ubuntu/14.04 (Trusty Tahr)
 # See https://rubinius-binaries-rubinius-com.s3-us-west-2.amazonaws.com/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Need sudo to install rubinius-3.69
 sudo: required
 
+# Ruby 2.1.0 is not available as a travis-ci precompiled binary for trusty
+# See http://rubies.travis-ci.org/
 before-install: rvm use 2.1.0 --install --binary --fuzzy --create
 
 # The binary for rubinius-3.69 is not available for

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ dist: trusty
 
 rvm:
   - 2.0.0
-  - 2.1.10
+  - 2.1.2
   - 2.4.0
   - jruby
   - rubinius-3.69

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+# Needed sudo to install rubinius-3.69
+sudo: required
+
+# The binary for rubinius-3.69 is not available for
+# ubuntu/12.04 (Precise Pangolin) but is for ubuntu/14.04 (Trusty Tahr)
+# See https://rubinius-binaries-rubinius-com.s3-us-west-2.amazonaws.com/
 dist: trusty
 
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: required
 # The binary for rubinius-3.69 is not available for
 # ubuntu/12.04 (Precise Pangolin) but is for ubuntu/14.04 (Trusty Tahr)
 # See https://rubinius-binaries-rubinius-com.s3-us-west-2.amazonaws.com/
+#
+# Note: travis-ci uses precise by default
 dist: trusty
 
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Needed sudo to install rubinius-3.69
+# Need sudo to install rubinius-3.69
 sudo: required
 
 # The binary for rubinius-3.69 is not available for


### PR DESCRIPTION
Concessions:
- Needed to upgrade distro because rubinius no longer supports Precise  
(which is chosen by default) and Travis-CI [advises to use Trusty instead](https://docs.travis-ci.com/user/languages/ruby/#Supported-Ruby-Versions-and-RVM).
- Needed to change ruby-2.1.0 to ruby-2.1.2 because the former is [not available as a pre-compiled binary from Travis-CI with Trusty](http://rubies.travis-ci.org/).

I hope others are OK with these concessions.