### PR TITLE
Add gemspec requirements attribute

### DIFF
--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -44,4 +44,6 @@ Ruby-Graphviz no longer supports Ruby < 1.9.3
   s.add_development_dependency 'test-unit'
 
   s.required_ruby_version = '>= 1.9.3'
+
+  s.requirements << 'GraphViz'
 end


### PR DESCRIPTION
This information will appear on the gem's page on rubygems.org.
http://guides.rubygems.org/specification-reference/#requirements