### PR TITLE
Added explicitly declaration for Open3 module on GraphVizTest.

### DIFF
--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 class GraphVizTest < Test::Unit::TestCase
   # you can run a subset of all the samples like this:
   #  ruby test/test_examples.rb  --name='/sample3[6-9]/'
@@ -96,7 +98,7 @@ class GraphVizTest < Test::Unit::TestCase
     FileUtils.rm_rf OutputDir
   end
   FileUtils.cp_r ExampleDir, OutputDir
-  
+
   samples = Dir[File.join(OutputDir,'sample*.rb')].sort
   samples.each {|path| make_sample_test_method(path) }
 


### PR DESCRIPTION
Hi, I got test fail with all of ruby-graphviz tests. Like this:

```
Failure:
  got exception on sample42.rb: uninitialized constant GraphVizTest::Open3.
  <false> is not true.
test_sample42(GraphVizTest)
/path/to/glejeune/Ruby-Graphviz/test/test_examples.rb:118:in `rescue in assert_sample_file_has_no_output'
/path/to/glejeune/Ruby-Graphviz/test/test_examples.rb:113:in `assert_sample_file_has_no_output'
/path/to/glejeune/Ruby-Graphviz/test/test_examples.rb:90:in `block in make_sample_test_method'
```

GraphVizTest references `Open3`. but `Open3` is not working without explicit declaration. I fixed it.