### PR TITLE
Prevent exceptions being masked by undefined method errors in ruby 2.4

### DIFF
--- a/lib/graphviz/utils.rb
+++ b/lib/graphviz/utils.rb
@@ -55,7 +55,7 @@ class GraphViz
 
     def output_from_command(cmd) #:nodoc:
       output, errors, status = output_and_errors_from_command(cmd)
-      if (status.nil? && (errors.nil? || errors.strip.empty?)) || status.zero?
+      if (status.nil? && (errors.nil? || errors.strip.empty?)) || status == 0
         output
       else
         raise "Error from #{cmd}:\n#{errors}"


### PR DESCRIPTION
@glejeune - This may be a ruby 2.4 idiosynracy, I didn't take the time to diagnose it further.

Essentially, sometimes the status returned from output_and_errors_from_command is nil, which does not respond to `zero?`; causing  the actual commands errors to be masked.

This patches that so the underlying graphviz usage errors can bubble up.

I believe this resolves both https://github.com/glejeune/Ruby-Graphviz/issues/133 and https://github.com/glejeune/Ruby-Graphviz/issues/125