### PR TITLE
Add missing rexml dependency

### DIFF
--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -36,6 +36,8 @@ Last (important) changes :
 Ruby-Graphviz no longer supports Ruby < 1.9.3
   }
 
+  s.add_dependency "rexml"
+
   s.add_development_dependency 'mustache', "~> 0.99.8" if RUBY_VERSION =~ /^1[.]9[.]/
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'


### PR DESCRIPTION
The next version of ruby will not include rexml as a default gem, so it will need to be explicitly added as a dependency.

See https://bugs.ruby-lang.org/issues/16485#change-83794