### PR TITLE
Fix gemspec

### DIFF
--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.rdoc", "COPYING.rdoc", "AUTHORS.rdoc", "CHANGELOG.rdoc"]
   s.rdoc_options = ["--title", "Ruby/GraphViz", "--main", "README.rdoc"]
   s.post_install_message = %{
-You need to install GraphViz (https://graphviz.org/) to use this Gem.
+You need to install GraphViz (https://graphviz.org) to use this Gem.
 
 For more information about Ruby-Graphviz :
 * Doc: https://rdoc.info/github/glejeune/Ruby-Graphviz

--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.extra_rdoc_files = ["README.rdoc", "COPYING.rdoc", "AUTHORS.rdoc", "CHANGELOG.rdoc"]
-  s.rdoc_options = ["--title", "Ruby/GraphViz", "--main", "README.rdoc"]
+  s.extra_rdoc_files = ["README.md", "COPYING.md", "CHANGELOG.md"]
+  s.rdoc_options = ["--title", "Ruby/GraphViz", "--main", "README.md"]
   s.post_install_message = %{
 You need to install GraphViz (https://graphviz.org) to use this Gem.
 

--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -25,10 +25,10 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.rdoc", "COPYING.rdoc", "AUTHORS.rdoc", "CHANGELOG.rdoc"]
   s.rdoc_options = ["--title", "Ruby/GraphViz", "--main", "README.rdoc"]
   s.post_install_message = %{
-You need to install GraphViz (http://graphviz.org/) to use this Gem.
+You need to install GraphViz (https://graphviz.org/) to use this Gem.
 
 For more information about Ruby-Graphviz :
-* Doc: http://rdoc.info/projects/glejeune/Ruby-Graphviz
+* Doc: https://rdoc.info/projects/glejeune/Ruby-Graphviz
 * Sources: https://github.com/glejeune/Ruby-Graphviz
 * Issues: https://github.com/glejeune/Ruby-Graphviz/issues
   }

--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 You need to install GraphViz (https://graphviz.org/) to use this Gem.
 
 For more information about Ruby-Graphviz :
-* Doc: https://rdoc.info/projects/glejeune/Ruby-Graphviz
+* Doc: https://rdoc.info/github/glejeune/Ruby-Graphviz
 * Sources: https://github.com/glejeune/Ruby-Graphviz
 * Issues: https://github.com/glejeune/Ruby-Graphviz/issues
   }

--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.rubyforge_project = 'ruby-asp'
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc", "COPYING.rdoc", "AUTHORS.rdoc", "CHANGELOG.rdoc"]
   s.rdoc_options = ["--title", "Ruby/GraphViz", "--main", "README.rdoc"]
   s.post_install_message = %{


### PR DESCRIPTION
I noticed that the gem fails to be built on current master like this:

```
$ gem build ruby-graphviz.gemspec
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from ruby-graphviz.gemspec:23.
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from ruby-graphviz.gemspec:24.
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["AUTHORS.rdoc", "CHANGELOG.rdoc", "COPYING.rdoc", "README.rdoc"] are not files
```

This PR fixes the gemspec so that it can be built again, and it also adds a few other tiny improvements to it.

Closes #141.