### PR TITLE
issue #115 control binmode based on output format

### DIFF
--- a/lib/graphviz.rb
+++ b/lib/graphviz.rb
@@ -189,7 +189,7 @@ class GraphViz
   end
 
   def add_edge( oNodeOne, oNodeTwo, hOpts = {} )
-    if oNodeTwo.kind_of? Array or oNodeOne.kind_of? Array 
+    if oNodeTwo.kind_of? Array or oNodeOne.kind_of? Array
       raise ArgumentError, "use `add_edges' to add several edges at the same time"
     end
     add_edges(oNodeOne, oNodeTwo, hOpts)
@@ -603,7 +603,12 @@ class GraphViz
                xOutputWithoutFile +
                [tmpPath]
 
-        xOutput << output_from_command( xCmd )
+        # text outputs like SVG should be computed using binmode=false, issue #115
+        textmode = if @filename.nil? or @filename == String
+          TEXT_FORMATS.include?(@format) or
+          TEXT_FORMATS.any?{|f| (@output || {}).keys.include?(f)}
+        end
+        xOutput << output_from_command( xCmd, binmode: !textmode )
       end
 
       # Not Hugly
@@ -629,7 +634,7 @@ class GraphViz
 
     @elements_order.each { |kElement|
       is_new_type = script_data.type != kElement["type"]
-      if is_new_type 
+      if is_new_type
         script << script_data unless script_data.type.nil? or script_data.empty?
         script_data = DOTScriptData.new(kElement["type"])
       end

--- a/lib/graphviz/constants.rb
+++ b/lib/graphviz/constants.rb
@@ -299,5 +299,9 @@ class GraphViz
 
     ## Const: Edge attributes
     EDGESATTRS = GraphViz::Constants::getAttrsFor( /E/ )
+
+    # output types that produce text (i.e. not binary)
+    TEXT_FORMATS = %w[ svg tk plain vml json dot].freeze
+
   end
 end

--- a/lib/graphviz/utils.rb
+++ b/lib/graphviz/utils.rb
@@ -34,7 +34,7 @@ class GraphViz
       return nil
     end
 
-    def output_and_errors_from_command(cmd) #:nodoc:
+    def output_and_errors_from_command(cmd, binmode: true) #:nodoc:
       unless defined? Open3
         begin
           require 'open3'
@@ -43,7 +43,7 @@ class GraphViz
         end
       end
       begin
-        out, err, status = Open3.capture3(*cmd, :binmode => true)
+        out, err, status = Open3.capture3(*cmd, :binmode => binmode)
         [out, err, status.exitstatus]
       rescue NotImplementedError, NoMethodError
         IO.popen( *cmd ) do |stdout|
@@ -53,8 +53,8 @@ class GraphViz
       end
     end
 
-    def output_from_command(cmd) #:nodoc:
-      output, errors, status = output_and_errors_from_command(cmd)
+    def output_from_command(cmd, binmode: true) #:nodoc:
+      output, errors, status = output_and_errors_from_command(cmd, binmode: binmode)
       if (status.nil? && (errors.nil? || errors.strip.empty?)) || status.zero?
         output
       else
@@ -64,4 +64,3 @@ class GraphViz
 
   end
 end
-


### PR DESCRIPTION
The Open3.capture3 command should use binmode: false when the Graphviz command output is text based, e.g. SVG, DOT.  This will prevent cross encoding errors and finally close #115.