### PR TITLE
Add JSON to supported formats

### DIFF
--- a/lib/graphviz/constants.rb
+++ b/lib/graphviz/constants.rb
@@ -88,6 +88,7 @@ class GraphViz
       "vtx",
       "wbmp",
       "xlib",
+      "json",
       "none"
     ]
 


### PR DESCRIPTION
Graphviz now supports JSON output format - [https://graphviz.org/docs/outputs/json/](https://graphviz.org/docs/outputs/json/)

The changes should be reflected in this library.