### PR TITLE
Update document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Copyright (C) 2004-2018 Gregoire Lejeune
 
-* Doc : http://rdoc.info/projects/glejeune/Ruby-Graphviz
+* Doc : https://rubydoc.info/projects/glejeune/Ruby-Graphviz
 * Sources : https://github.com/glejeune/Ruby-Graphviz
 * On Rubygems: https://rubygems.org/gems/ruby-graphviz
 

--- a/ruby-graphviz.gemspec
+++ b/ruby-graphviz.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 You need to install GraphViz (https://graphviz.org) to use this Gem.
 
 For more information about Ruby-Graphviz :
-* Doc: https://rdoc.info/github/glejeune/Ruby-Graphviz
+* Doc: https://rubydoc.info/projects/glejeune/Ruby-Graphviz
 * Sources: https://github.com/glejeune/Ruby-Graphviz
 * Issues: https://github.com/glejeune/Ruby-Graphviz/issues
   }


### PR DESCRIPTION
## what
I updated document link ( http://rdoc.info/projects/glejeune/Ruby-Graphviz -> https://rubydoc.info/projects/glejeune/Ruby-Graphviz )


## why
I tried to access http://rdoc.info/projects/glejeune/Ruby-Graphviz but redirected.( got error message `ERR_TOO_MANY_REDIRECTS` )

https://github.com/docmeta/rubydoc.info is alternative rdoc.info , so looks better to change it.
