### PR TITLE
Force mutable Strings to address upcoming Ruby default frozen strings

### DIFF
--- a/examples/sample44.rb
+++ b/examples/sample44.rb
@@ -88,7 +88,7 @@ g.edge["arrowhead"] = "normal"
 "rvee",
 "rveervee"
 ].each { |s|
-  p = "p_" << s
+  p = String.new("p_") << s
   g.add_nodes( p, "shape" => "point" )
   g.add_nodes( s )
   g.add_edges( p, s, "arrowhead" => s )

--- a/lib/graphviz.rb
+++ b/lib/graphviz.rb
@@ -527,7 +527,7 @@ class GraphViz
       xOutputString = (@filename == String ||
         @output.any? {|format, file| file == String })
 
-      xOutput = ""
+      xOutput = String.new
       if @format.to_s == "none" or @output.any? {|fmt, fn| fmt.to_s == "none"}
         if xOutputString
           xOutput << xDOTScript

--- a/lib/graphviz/core_ext.rb
+++ b/lib/graphviz/core_ext.rb
@@ -1,6 +1,6 @@
 class String
    def self.random(size)
-      s = ""
+      s = String.new
       d = ("a".."z").to_a + ("A".."Z").to_a + ("0".."9").to_a
       size.times {
          s << d[rand(d.size)]

--- a/lib/graphviz/dot_script.rb
+++ b/lib/graphviz/dot_script.rb
@@ -51,7 +51,7 @@ class GraphViz
     def_delegators :@script, :end_with?
 
     def initialize
-      @script = ''
+      @script = String.new
     end
 
     def append(line)

--- a/lib/graphviz/edge.rb
+++ b/lib/graphviz/edge.rb
@@ -165,10 +165,10 @@ class GraphViz
       # reserved words, they aren't accepted in dot as node name
       reserved_names = ["node", "edge","graph", "digraph", "subgraph", "strict"]
 
-      xOut = reserved_names.include?(self.node_one) ? "" << "_" + self.node_one : "" << self.node_one
+      xOut = reserved_names.include?(self.node_one) ? String.new << "_" + self.node_one : String.new << self.node_one
       xOut = xOut << xLink
       xOut = reserved_names.include?(self.node_two) ? xOut << "_" + self.node_two : xOut << self.node_two
-      xAttr = ""
+      xAttr = String.new
       xSeparator = ""
       @edge_attributes.data.each do |k, v|
         xAttr << xSeparator + k + " = " + v.to_gv

--- a/lib/graphviz/node.rb
+++ b/lib/graphviz/node.rb
@@ -143,8 +143,8 @@ class GraphViz
          # add a check to see if the node names are valid
          # if they aren't is added an _ before
          # and the print staies the same, because of the label
-         xOut = reserved_names.include?(node_id) ? "" << "_" + node_id : "" << node_id
-         xAttr = ""
+         xOut = reserved_names.include?(node_id) ? String.new << "_" + node_id : String.new << node_id
+         xAttr = String.new
          xSeparator = ""
 
          if @node_attributes.data.has_key?("label") and @node_attributes.data.has_key?("html")

--- a/lib/graphviz/xml.rb
+++ b/lib/graphviz/xml.rb
@@ -45,7 +45,7 @@ class GraphViz
     #   * :attrs : show XML attributes (default true)
     #
     def initialize( xml_file, *options )
-      @node_name = "00000"
+      @node_name = String.new("00000")
 	   @show_text = true
 	   @show_attributes = true
 
@@ -88,7 +88,7 @@ class GraphViz
         text_node_name = local_node_name.clone
         text_node_name << "111"
 
-        xText = ""
+        xText = String.new
         xSep = ""
         xml_node.texts().each do |l|
           x = l.value.chomp.strip


### PR DESCRIPTION
Ruby is slowly moving towards using [frozen string literals by default](https://bugs.ruby-lang.org/issues/20205). As of Ruby 3.4 it now produces a warning whenever a String literal modifies a value which will be default frozen in the future.

From this project:

```
lib/graphviz.rb:533: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
lib/graphviz/dot_script.rb:58: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

This change minimally modifies the places where a mutable String is required to use String.new instead of a bare String literal. This is a no-op for existing apps not using default frozen strings, but allows all the benefits for applications supporting it.

Running the tests with the upcoming behavior enabled on Ruby 3.4:

```
RUBYOPT="--enable=frozen_string_literal" rake
```

Before:

```
100 tests, 303 assertions, 71 failures, 5 errors, 0 pendings, 0 omissions, 0 notifications
24% passed
```

After:

```
100 tests, 258 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```