### PR TITLE
Remove duplicate key bin-dir

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -281,7 +281,6 @@ class ConfigTable
     'site-ruby-common' => 'siteruby',     # For backward compatibility
     'site-ruby'        => 'siterubyver',  # For backward compatibility
     'bin-dir'          => 'bindir',
-    'bin-dir'          => 'bindir',
     'rb-dir'           => 'rbdir',
     'so-dir'           => 'sodir',
     'data-dir'         => 'datadir',


### PR DESCRIPTION
Removes an obvious typo of a duplicate key on two lines in a row. Fixes this warning:

```
setup.rb:283: warning: key "bin-dir" is duplicated and overwritten on line 284
```